### PR TITLE
Remove apparent temperature from weightings

### DIFF
--- a/constants.py
+++ b/constants.py
@@ -8,8 +8,7 @@ GOOGLE_API_KEY = os.environ.get("GOOGLE_API_KEY")
 TEST_EMAIL_ACCOUNT = os.environ.get("TEST_EMAIL_ACCOUNT")
 DEFAULT_WEIGHTINGS = {'precip_probability': -10,
                       'precip_intensity': -2,
-                      'cloud_cover': -5,
-                      'apparent_temperature': 3}
+                      'cloud_cover': -5}
 
 S3_ACCESS_KEY = os.getenv('AWS_ACCESS_KEY_ID_WINE')
 S3_SECRET_KEY = os.getenv('AWS_SECRET_ACCESS_KEY_WINE')


### PR DESCRIPTION
Temperature is scaled completely differently from other inputs so this produced odd results. More care required to execute this properly.