### PR TITLE
Apply user preferences to weather window calculation

### DIFF
--- a/preferences.py
+++ b/preferences.py
@@ -1,4 +1,5 @@
 from dateutil import parser
+import models
 
 HOURS = []
 [[HOURS.append(str(hour) + period) for hour in range(1, 13)] for period in ['AM', 'PM']]
@@ -28,5 +29,4 @@ class DefaultPreferences:
 
 def parse_time_to_int(time_string):
     return parser.parse(time_string).hour
-
 

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -49,7 +49,7 @@ def test_db(setup_test_app):
     yield db
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture(scope="module")
 def test_client(setup_test_app):
     client, _, _ = setup_test_app
 
@@ -89,14 +89,14 @@ test_locations = [MockLocation(place='Redland, Bristol, UK',
                                lon=-73.6)]
 
 
-@pytest.fixture(scope='module')
+@pytest.fixture(scope="module")
 def test_form(test_client, test_app):
     with test_app.app_context(), test_app.test_request_context():
         form = PreferencesForm()
         yield form
 
 
-@pytest.fixture(scope='module')
+@pytest.fixture(scope="module")
 def user_with_hot_preferences(test_db):
     user = actions.add_new_user_to_db_with_default_preferences(email=test_email,
                                                                location=actions.add_or_return_location(test_locations[0].place))

--- a/tests/test_preferences.py
+++ b/tests/test_preferences.py
@@ -1,11 +1,13 @@
 import pytest
 
 from preferences import DefaultPreferences
-from tests.fixtures import test_locations
+from tests.fixtures import test_locations, test_form, test_client, setup_test_app, test_app, test_db, \
+    user_with_hot_preferences
 
 # TODO these tests are pretty feeble, but I don't know how to mock the submission of forms with different values
 
 test_location = test_locations[0]
+
 
 class TestPreferencesForm:
 

--- a/tests/test_preferences.py
+++ b/tests/test_preferences.py
@@ -1,41 +1,11 @@
 import pytest
 
-from forms import PreferencesForm
 from preferences import DefaultPreferences
-import actions
-import models
-from tests.fixtures import setup_test_app, test_app, test_client, test_db, test_locations
-
+from tests.fixtures import test_locations
 
 # TODO these tests are pretty feeble, but I don't know how to mock the submission of forms with different values
-test_email = 'test@gmail.com'
+
 test_location = test_locations[0]
-
-
-@pytest.fixture(scope='module')
-def test_form(test_client, test_app):
-    with test_app.app_context(), test_app.test_request_context():
-        form = PreferencesForm()
-        yield form
-
-
-@pytest.fixture(scope='module')
-def user_with_non_default_preferences(test_db):
-    user = actions.add_new_user_to_db_with_default_preferences(email=test_email,
-                                                               location=actions.add_or_return_location(test_location.place))
-
-    # Retrieve existing preferences, we don't want to add an entirely new row
-    prefs = user.preferences
-    prefs.day_start = 9
-    prefs.day_end = 16
-    prefs.temperature = 'hot'
-    prefs.activities = [actions.add_or_return_activity('rowing'),
-                        actions.add_or_return_activity('swimming')]
-
-    models.db.session.add(user)
-    models.db.session.commit()
-    yield user
-
 
 class TestPreferencesForm:
 
@@ -52,8 +22,8 @@ class TestPreferencesForm:
     def test_default_activities_are_none(self, test_form):
         assert test_form.activities.default is None
 
-    def test_loading_of_values_from_db(self, test_form, test_db, user_with_non_default_preferences):
-        test_form.initialize_from_db(user_with_non_default_preferences.preferences)
+    def test_loading_of_values_from_db(self, test_form, test_db, user_with_hot_preferences):
+        test_form.initialize_from_db(user_with_hot_preferences.preferences)
 
         assert test_form.day_start.default != DefaultPreferences.day_start
         assert test_form.day_end.default != DefaultPreferences.day_end
@@ -63,3 +33,4 @@ class TestPreferencesForm:
     @pytest.mark.skip('Incomplete implementation')
     def test_update_preferences_from_form(self):
         pass
+

--- a/weather.py
+++ b/weather.py
@@ -6,6 +6,7 @@ import pandas as pd
 import requests
 
 import constants
+import models
 from constants import DARKSKY_API_KEY
 from preferences import DefaultPreferences
 
@@ -116,6 +117,14 @@ class WeatherWindowFinder:
         df['total_score'] = df.filter(like='_score').sum(axis=1)
 
         return df.loc[df['total_score'].idxmax()]
+
+
+def convert_db_preferences_to_weather_preferences(preferences: models.Preferences):
+    return Preferences(temperature_weighting=constants.TEMPERATURE_WEIGHTINGS,
+                       weightings=constants.DEFAULT_WEIGHTINGS,
+                       day_start=preferences.day_start,
+                       day_end=preferences.day_end,
+                       temperature=preferences.temperature)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Slight risky merge - applying user preferences to weather window calculation.

It's risky because I haven't had time to test it really thoroughly, and I packaged all the preferences work together. 

Next time, should:

- add the preferences page
- implement the use of preferences in the window finder, with sensible defaults
- make the access to preferences page invisible so I have time to test it properly 