### PR TITLE
Hotfix/delete prefs

### DIFF
--- a/actions.py
+++ b/actions.py
@@ -146,9 +146,12 @@ def get_user(email: str):
 
 
 def delete_user(email: str):
-    user = get_user(email)
-    models.db.session.delete(user)
-    print(f'Deleting user {email}')
+    with models.db.session.no_autoflush:
+        user = get_user(email)
+        models.db.session.delete(user)
+        # Delete user preferences too to solve non-null constraint
+        models.db.session.delete(user.preferences)
+    print(f'Deleting user {email} and associated preferences')
     models.db.session.commit()
 
 


### PR DESCRIPTION
Cannot delete user without deleting preferences row, because preference row has a non-null constraint on user.

Longer term solution is to use cascade: https://docs.sqlalchemy.org/en/13/orm/cascades.html